### PR TITLE
Add dex to caasp kfdef

### DIFF
--- a/kfdef/kfctl_caasp.yaml
+++ b/kfdef/kfctl_caasp.yaml
@@ -5,12 +5,24 @@ metadata:
 spec:
   applications:
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: application/application
+    name: application
+  - kustomizeConfig:
       parameters:
       - name: namespace
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-crds
+        path: istio-1-3-1/istio-crds-1-3-1
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +30,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-install
+        path: istio-1-3-1/istio-install-1-3-1
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +38,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/cluster-local-gateway
+        path: istio-1-3-1/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
@@ -39,7 +51,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'OFF'
+        value: 'ON'
       repoRef:
         name: manifests
         path: istio/istio
@@ -91,6 +103,48 @@ spec:
         name: manifests
         path: cert-manager/cert-manager
     name: cert-manager
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: namespace
+        value: istio-system
+      - name: userid-header
+        value: kubeflow-userid
+      - name: oidc_provider
+        value: http://dex.auth.svc.cluster.local:5556/dex
+      - name: oidc_redirect_uri
+        value: /login/oidc
+      - name: oidc_auth_url
+        value: /dex/auth
+      - name: skip_auth_uri
+        value: /dex
+      - name: client_id
+        value: kubeflow-oidc-authservice
+      repoRef:
+        name: manifests
+        path: istio/oidc-authservice
+    name: oidc-authservice
+  - kustomizeConfig:
+      overlays:
+      - istio
+      parameters:
+      - name: namespace
+        value: auth
+      - name: issuer
+        value: http://dex.auth.svc.cluster.local:5556/dex
+      - name: client_id
+        value: kubeflow-oidc-authservice
+      - name: oidc_redirect_uris
+        value: '["/login/oidc"]'
+      - name: static_email
+        value: admin@kubeflow.org
+      - name: static_password_hash
+        value: $2y$12$ruoM7FqXrpVgaol44eRZW.4HWS8SAvg6KYVVSCIwKQPBmTpCm.EeO
+      repoRef:
+        name: manifests
+        path: dex-auth/dex-crds
+    name: dex
   - kustomizeConfig:
       repoRef:
         name: manifests


### PR DESCRIPTION
Add the required kustomize configs to the caasp kfdef file and ensure
istio is version 1.3.1.

Partial fix: https://github.com/SUSE/avant-garde/issues/1474