### PR TITLE
Removed istio from kf install

### DIFF
--- a/kfdef/kfctl_caasp.yaml
+++ b/kfdef/kfctl_caasp.yaml
@@ -377,6 +377,8 @@ spec:
       parameters:
       - name: admin
         value: johnDoe@acme.com
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: profiles

--- a/kfdef/kfctl_caasp.yaml
+++ b/kfdef/kfctl_caasp.yaml
@@ -22,22 +22,6 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-crds-1-3-1
-    name: istio-crds
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio-1-3-1/istio-install-1-3-1
-    name: istio-install
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
         path: istio-1-3-1/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:


### PR DESCRIPTION
removed istio from the base kubeflow install.
Dont merge yet. it's a WIP.
istio should be installed following standard SUSE documentation

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
