### PR TITLE
Add PSPs for SYS_PTRACE and NET_ADMIN

### DIFF
--- a/jupyter/notebook-controller/base/cluster-role.yaml
+++ b/jupyter/notebook-controller/base/cluster-role.yaml
@@ -47,7 +47,6 @@ rules:
   - virtualservices
   verbs:
   - '*'
-
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -86,6 +85,14 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - notebook-controller-psp
 
 ---
 

--- a/jupyter/notebook-controller/base/kustomization.yaml
+++ b/jupyter/notebook-controller/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - deployment.yaml
 - service-account.yaml
 - service.yaml
+- psp.yaml
 namePrefix: notebook-controller-
 namespace: kubeflow
 commonLabels:

--- a/jupyter/notebook-controller/base/psp.yaml
+++ b/jupyter/notebook-controller/base/psp.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: psp
+spec:
+  privileged: false
+  allowedCapabilities:
+  - NET_ADMIN
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - hostPath
+  - configMap
+  - secret
+  - emptyDir
+  - downwardAPI
+  - projected
+  - persistentVolumeClaim
+  - nfs
+  - rbd
+  - cephFS
+  - glusterfs
+  - fc
+  - iscsi
+  - cinder
+  - gcePersistentDisk
+  - awsElasticBlockStore
+  - azureDisk
+  - azureFile
+  - vsphereVolume

--- a/pipeline/pipelines-runner/base/cluster-role.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role.yaml
@@ -74,3 +74,11 @@ rules:
   - jobs
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - suse.caasp.psp.kubeflow.pns

--- a/pipeline/pipelines-runner/base/kustomization.yaml
+++ b/pipeline/pipelines-runner/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - cluster-role-binding.yaml
 - cluster-role.yaml
 - service-account.yaml
+- psp.yaml

--- a/pipeline/pipelines-runner/base/psp.yaml
+++ b/pipeline/pipelines-runner/base/psp.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.kubeflow.pns
+spec:
+  privileged: false
+  allowedCapabilities:
+  - SYS_PTRACE
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - downwardAPI
+  - projected
+  - persistentVolumeClaim
+  - nfs
+  - rbd
+  - cephFS
+  - glusterfs
+  - fc
+  - iscsi
+  - cinder
+  - gcePersistentDisk
+  - awsElasticBlockStore
+  - azureDisk
+  - azureFile
+  - vsphereVolume


### PR DESCRIPTION
Since CaaSP comes with PSPs enabled, kubeflow needs certain capabilities
added. The pipeline runner account needs to be able to create pods in
the kubeflow namespace that add the SYS_PTRACE capability, and the
notebook controller needs to create pods in a custom namespace that use
the NET_ADMIN namespace.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
