### PR TITLE
Fix centraldashboard role bindings

### DIFF
--- a/common/centraldashboard/base_v3/clusterrole-binding.yaml
+++ b/common/centraldashboard/base_v3/clusterrole-binding.yaml
@@ -11,4 +11,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: centraldashboard
-  namespace: $(namespace)

--- a/common/centraldashboard/base_v3/role-binding.yaml
+++ b/common/centraldashboard/base_v3/role-binding.yaml
@@ -11,4 +11,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: centraldashboard
-  namespace: $(namespace)


### PR DESCRIPTION
The $(namespace) variable isn't interpolated by kustomize because it's
not defined in params.yaml, and it's not needed because the namespace is
already defined in kustomize.yaml. Without this patch, the
centraldashboard service account does not have any roles or clusterroles
bound because the bindings refer to a service account in a nonexistent
namespace '$(namespace)'.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
