### PR TITLE
Update the centraldashboard image to a newly built image.

### DIFF
--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/centraldashboard
   newName: gcr.io/kubeflow-images-public/centraldashboard
-  newTag: vmaster-gf39279c0
+  digest: sha256:fb72156fad20ce408304c3b5b4a2fa6c56d884f9e73923706ef8d80218b612bd
 configMapGenerator:
 - envs:
   - params.env


### PR DESCRIPTION
* Update the centraldashboard image to a newly built image.

(cherry picked from commit 0dc222c07365b600c6d2e65b45fa3e4a13c77952)

This is a cherry-pick from upstream to resolve the crashing dashboard issue.