### PR TITLE
Remove anonymous envoy filter

### DIFF
--- a/kfdef/kfctl_caasp.yaml
+++ b/kfdef/kfctl_caasp.yaml
@@ -57,14 +57,6 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio/add-anonymous-user-filter
-    name: add-anonymous-user-filter
-  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds


### PR DESCRIPTION
Without this patch, users authenticated with dex end up having
",anonymous@kubeflow.org" appended to their usernames, which means that
needs to be appended in their role bindings. This isn't required since
the users are not anonymous, and it's misleading since users aren't
coming from a kubeflow-managed identity provider. This change removes
the filter.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
