### PR TITLE
Remove usage reporting

### DIFF
--- a/kfdef/kfctl_caasp.yaml
+++ b/kfdef/kfctl_caasp.yaml
@@ -248,18 +248,6 @@ spec:
     name: kfserving-install
   - kustomizeConfig:
       overlays:
-      - application
-      parameters:
-      - name: usageId
-        value: <randomly-generated-id>
-      - name: reportUsage
-        value: 'true'
-      repoRef:
-        name: manifests
-        path: common/spartakus
-    name: spartakus
-  - kustomizeConfig:
-      overlays:
       - istio
       repoRef:
         name: manifests


### PR DESCRIPTION
We don't need to force our users to report their usage to a third party.
See also[1].

[1] https://www.kubeflow.org/docs/other-guides/usage-reporting/

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
