### PR TITLE
Add NET_RAW capability to notebook PSP

### DIFF
--- a/jupyter/notebook-controller/base/psp.yaml
+++ b/jupyter/notebook-controller/base/psp.yaml
@@ -6,6 +6,7 @@ spec:
   privileged: false
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:


### PR DESCRIPTION
With Istio 1.3 it seemed like NET_ADMIN was sufficient for launching
notebooks, but Istio 1.5 also wants NET_RAW[1].

[1] https://istio.io/latest/docs/ops/deployment/requirements/#required-pod-capabilities